### PR TITLE
Fix missing tool output and text content in Steps tab

### DIFF
--- a/src/services/parserService.ts
+++ b/src/services/parserService.ts
@@ -266,13 +266,22 @@ export class ParserService {
         }
       }
 
-      // Process tool results
-      if (event.type === 'user' && event.toolUseResult && event.sourceToolAssistantUUID) {
-        const toolStep = toolCallMap.get(event.sourceToolAssistantUUID);
-        if (toolStep && typeof toolStep.index === 'number') {
-          const result = event.toolUseResult;
-          steps[toolStep.index].toolResult = JSON.stringify(result);
-          steps[toolStep.index].toolSuccess = !result.is_error;
+      // Process tool results via message content (tool_result blocks keyed by tool_use_id)
+      if (event.type === 'user' && event.message?.content) {
+        const content = Array.isArray(event.message.content) ? event.message.content : [];
+        for (const block of content) {
+          if (block.type === 'tool_result' && block.tool_use_id) {
+            const toolStep = toolCallMap.get(block.tool_use_id);
+            if (toolStep && typeof toolStep.index === 'number') {
+              let result = block.content ?? '';
+              if (Array.isArray(result)) {
+                result = result.map((r: any) => r.text ?? JSON.stringify(r)).join('\n');
+              }
+              steps[toolStep.index].toolResult =
+                typeof result === 'string' ? result : JSON.stringify(result);
+              steps[toolStep.index].toolSuccess = !block.is_error;
+            }
+          }
         }
       }
     }

--- a/webview/src/components/StepsTab.tsx
+++ b/webview/src/components/StepsTab.tsx
@@ -183,6 +183,15 @@ const StepsTab = ({ steps, subagents, findings, highlightStep }: Props) => {
                     </div>
                   )}
 
+                  {step.type === 'text' && step.content && (
+                    <div className="detail-section">
+                      <div className="detail-label">Text</div>
+                      <pre className="detail-text">
+                        {step.content.length > 2000 ? step.content.substring(0, 2000) + '...' : step.content}
+                      </pre>
+                    </div>
+                  )}
+
                   {step.usage && (
                     <div className="detail-section">
                       <div className="detail-label">Token Usage</div>


### PR DESCRIPTION
## Summary

- **Fixes #3** — Tool output was never displayed because `toolCallMap` was keyed by `tool_use` block ID (e.g. `toolu_01...`) but the lookup used `event.sourceToolAssistantUUID` (the assistant event UUID). These are different values so the match always failed. Fixed by iterating `event.message.content` for `tool_result` blocks and matching via `tool_use_id`.
- **Fixes #4** — Text step content was correctly parsed and stored in `step.content`, but `StepsTab.tsx` only rendered content for `thinking` type steps. Added the equivalent display block for `text` type steps.

## Files changed

- `src/services/parserService.ts` — correct tool result matching logic
- `webview/src/components/StepsTab.tsx` — render text content when a text step is expanded

## Test plan

- [ ] Open a session with tool calls — expanding a tool step should now show **Tool Result**
- [ ] Open a session with assistant text responses — expanding a text step should now show **Text** content