### PR TITLE
Add Workspace Dashboard: cross-session token & cost rollups

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,12 @@
         "command": "argus.setGroupModel",
         "title": "Group by Model",
         "category": "Argus"
+      },
+      {
+        "command": "argus.openWorkspaceDashboard",
+        "title": "Open Workspace Dashboard",
+        "icon": "$(dashboard)",
+        "category": "Argus"
       }
     ],
     "submenus": [
@@ -191,6 +197,11 @@
           "command": "argus.clearFilters",
           "when": "view == argusSessionList && argus.hasActiveFilters",
           "group": "navigation@2"
+        },
+        {
+          "command": "argus.openWorkspaceDashboard",
+          "when": "view == argusSessionList",
+          "group": "navigation@0"
         },
         {
           "command": "argus.refreshSessions",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,9 +3,11 @@ import * as vscode from 'vscode';
 import { DiscoveryService } from './services/discoveryService';
 import { ParserService } from './services/parserService';
 import { AnalyzerService } from './services/analyzerService';
+import { AggregationService } from './services/aggregationService';
 import { SessionWebviewProviderReact } from './providers/sessionWebviewProviderReact';
 import { SessionListViewProvider } from './providers/sessionListViewProvider';
 import { DatePickerPanel } from './providers/datePickerPanel';
+import { WorkspaceDashboardProvider } from './providers/workspaceDashboardProvider';
 import { FilterState, DEFAULT_FILTER_STATE, GroupMode, DatePreset, SessionSummary } from './types/models';
 import { getClaudeConfigDir } from './utils/claudePaths';
 
@@ -14,6 +16,7 @@ export function activate(context: vscode.ExtensionContext) {
   const discoveryService = new DiscoveryService();
   const parserService = new ParserService();
   const analyzerService = new AnalyzerService();
+  const aggregationService = new AggregationService(discoveryService);
 
   // Initialize providers
   const webviewProvider = new SessionWebviewProviderReact(
@@ -271,6 +274,14 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('argus.setGroupNone', () => setGroupMode('none')),
     vscode.commands.registerCommand('argus.setGroupProject', () => setGroupMode('project')),
     vscode.commands.registerCommand('argus.setGroupModel', () => setGroupMode('model'))
+  );
+
+  // Workspace Dashboard — cross-session token + cost rollups across the
+  // user's whole ~/.claude/projects/ tree. Opens as a singleton webview panel.
+  context.subscriptions.push(
+    vscode.commands.registerCommand('argus.openWorkspaceDashboard', () => {
+      void WorkspaceDashboardProvider.show(context, aggregationService);
+    })
   );
 
   // Initial discovery — fire and forget; ensureSessions dedupes against the

--- a/src/providers/sessionWebviewProviderReact.ts
+++ b/src/providers/sessionWebviewProviderReact.ts
@@ -348,8 +348,14 @@ export class SessionWebviewProviderReact {
     const scriptUri = webview.asWebviewUri(
       vscode.Uri.file(path.join(webviewPath, 'assets', 'main.js'))
     );
+    const globalScriptUri = webview.asWebviewUri(
+      vscode.Uri.file(path.join(webviewPath, 'assets', 'global.js'))
+    );
     const styleUri = webview.asWebviewUri(
       vscode.Uri.file(path.join(webviewPath, 'assets', 'main.css'))
+    );
+    const globalStyleUri = webview.asWebviewUri(
+      vscode.Uri.file(path.join(webviewPath, 'assets', 'global.css'))
     );
 
     return `<!DOCTYPE html>
@@ -358,12 +364,14 @@ export class SessionWebviewProviderReact {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src ${webview.cspSource}; font-src ${webview.cspSource} https:; img-src ${webview.cspSource} https:;">
+    <link rel="stylesheet" href="${globalStyleUri}">
     <link rel="stylesheet" href="${styleUri}">
+    <link rel="modulepreload" href="${globalScriptUri}">
     <title>Argus Session Viewer</title>
   </head>
   <body>
     <div id="root"></div>
-    <script src="${scriptUri}"></script>
+    <script type="module" src="${scriptUri}"></script>
   </body>
 </html>`;
   }

--- a/src/providers/workspaceDashboardProvider.ts
+++ b/src/providers/workspaceDashboardProvider.ts
@@ -1,0 +1,112 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { AggregationService } from '../services/aggregationService';
+
+type WindowKey = '7d' | '30d' | 'mtd' | 'all';
+
+function windowRange(key: WindowKey): { from: number; to: number } {
+  const now = Date.now();
+  switch (key) {
+    case '7d': return { from: now - 7 * 86400000, to: now };
+    case '30d': return { from: now - 30 * 86400000, to: now };
+    case 'mtd': {
+      const d = new Date();
+      const start = new Date(d.getFullYear(), d.getMonth(), 1).getTime();
+      return { from: start, to: now };
+    }
+    case 'all':
+    default:
+      return { from: 0, to: now };
+  }
+}
+
+/**
+ * Opens (and reveals) the cross-session workspace dashboard webview panel.
+ * The panel is a singleton — re-running the command focuses the existing one.
+ */
+export class WorkspaceDashboardProvider {
+  private static _panel: vscode.WebviewPanel | undefined;
+
+  static async show(
+    context: vscode.ExtensionContext,
+    aggregation: AggregationService,
+  ): Promise<void> {
+    if (this._panel) {
+      this._panel.reveal(vscode.ViewColumn.One);
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      'argusWorkspaceDashboard',
+      'Argus: Workspace',
+      vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [vscode.Uri.file(path.join(context.extensionPath, 'out', 'webview'))],
+      },
+    );
+    this._panel = panel;
+
+    const webview = panel.webview;
+    const webviewRoot = vscode.Uri.file(path.join(context.extensionPath, 'out', 'webview'));
+    const cssUri = webview.asWebviewUri(vscode.Uri.joinPath(webviewRoot, 'assets', 'main.css'));
+    const jsUri = webview.asWebviewUri(vscode.Uri.joinPath(webviewRoot, 'assets', 'workspace.js'));
+    const csp = `default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com data:; img-src ${webview.cspSource} data:; script-src ${webview.cspSource};`;
+
+    webview.html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="${csp}" />
+  <title>Argus Workspace</title>
+  <link rel="stylesheet" href="${cssUri}" />
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="${jsUri}"></script>
+</body>
+</html>`;
+
+    let currentWindow: WindowKey = '7d';
+    let busy = false;
+
+    const runAggregation = async () => {
+      if (busy) return;
+      busy = true;
+      try {
+        webview.postMessage({ type: 'workspaceLoading' });
+        const { from, to } = windowRange(currentWindow);
+        const data = await aggregation.aggregateAll(
+          from,
+          to,
+          (done, total) => webview.postMessage({ type: 'workspaceProgress', done, total }),
+        );
+        webview.postMessage({ type: 'workspaceData', data });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage('Argus workspace aggregation failed: ' + msg);
+      } finally {
+        busy = false;
+      }
+    };
+
+    webview.onDidReceiveMessage((message) => {
+      if (message?.type === 'ready') {
+        if (message.window) currentWindow = message.window as WindowKey;
+        void runAggregation();
+      } else if (message?.type === 'setWindow') {
+        currentWindow = message.window as WindowKey;
+        void runAggregation();
+      } else if (message?.type === 'refresh') {
+        void runAggregation();
+      }
+    });
+
+    panel.onDidDispose(() => {
+      this._panel = undefined;
+    });
+
+    context.subscriptions.push(panel);
+  }
+}

--- a/src/services/aggregationService.ts
+++ b/src/services/aggregationService.ts
@@ -1,0 +1,334 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as readline from 'readline';
+import { DiscoveryService } from './discoveryService';
+import { calculateCost, Usage } from '../types/models';
+import { getClaudeConfigDir } from '../utils/claudePaths';
+
+export interface PerSessionAggregate {
+  sessionId: string;
+  filePath: string;
+  project: string;          // directory name under ~/.claude/projects/
+  model: string;            // primary model used
+  firstTimestamp: number;   // ms
+  lastTimestamp: number;    // ms
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  totalCost: number;
+  registryName?: string;
+  registrySection?: string;
+}
+
+export interface PerProjectAggregate {
+  project: string;          // dir name
+  sessionCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  totalCost: number;
+  lastActivity: number;     // ms
+  modelBreakdown: Record<string, number>; // model -> cost
+}
+
+export interface PerDayAggregate {
+  isoDate: string;          // YYYY-MM-DD (local time)
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  totalCost: number;
+  sessionCount: number;
+}
+
+export interface PerModelAggregate {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  totalCost: number;
+}
+
+export interface WorkspaceAggregate {
+  /** rolling window covered: [from, to] in ms */
+  windowFrom: number;
+  windowTo: number;
+  totalCost: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheReadTokens: number;
+  totalCacheCreateTokens: number;
+  perDay: PerDayAggregate[];        // sorted ascending by date
+  perProject: PerProjectAggregate[];// sorted descending by cost
+  perModel: PerModelAggregate[];    // sorted descending by cost
+  perSession: PerSessionAggregate[];// sorted descending by lastTimestamp
+  scannedFileCount: number;
+  scannedAt: number;
+}
+
+interface FileCacheEntry {
+  mtimeMs: number;
+  size: number;
+  agg: PerSessionAggregate;
+}
+
+function isoLocalDate(ms: number): string {
+  const d = new Date(ms);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Aggregates token usage and cost across every Claude Code session JSONL on
+ * disk. Streams each line so we don't load full transcripts into memory.
+ * Caches per-file results by (mtime, size) so repeat opens are fast.
+ */
+export class AggregationService {
+  private _fileCache = new Map<string, FileCacheEntry>();
+
+  constructor(private readonly _discovery: DiscoveryService) {}
+
+  /**
+   * Parse a single JSONL and produce a session-level aggregate. Uses the
+   * cache if the file's (mtime, size) is unchanged from last parse.
+   */
+  async aggregateFile(filePath: string): Promise<PerSessionAggregate | null> {
+    let stat: fs.Stats;
+    try {
+      stat = await fs.promises.stat(filePath);
+    } catch {
+      return null;
+    }
+    const cached = this._fileCache.get(filePath);
+    if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+      return cached.agg;
+    }
+
+    const sessionId = path.basename(filePath, '.jsonl');
+    const project = path.basename(path.dirname(filePath));
+    let model = 'unknown';
+    let firstTimestamp = 0;
+    let lastTimestamp = 0;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let cacheReadTokens = 0;
+    let cacheCreateTokens = 0;
+    let totalCost = 0;
+
+    const fileStream = fs.createReadStream(filePath);
+    const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let evt: any;
+      try {
+        evt = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      const ts = evt.timestamp ? Date.parse(evt.timestamp) : 0;
+      if (ts) {
+        if (!firstTimestamp || ts < firstTimestamp) firstTimestamp = ts;
+        if (ts > lastTimestamp) lastTimestamp = ts;
+      }
+      // Anthropic API response objects in Claude Code JSONL have
+      // message.model + message.usage on assistant responses.
+      const msg = evt.message;
+      const usage = msg?.usage;
+      if (msg?.model && typeof msg.model === 'string') {
+        model = msg.model;
+      }
+      if (usage && typeof usage === 'object') {
+        const u: Usage = {
+          input_tokens: usage.input_tokens || 0,
+          output_tokens: usage.output_tokens || 0,
+          cache_read_input_tokens: usage.cache_read_input_tokens || 0,
+          cache_creation_input_tokens: usage.cache_creation_input_tokens || 0,
+        };
+        inputTokens += u.input_tokens;
+        outputTokens += u.output_tokens;
+        cacheReadTokens += u.cache_read_input_tokens;
+        cacheCreateTokens += u.cache_creation_input_tokens;
+        totalCost += calculateCost(u, msg.model || model);
+      }
+    }
+
+    if (!firstTimestamp && !lastTimestamp) return null;
+
+    const agg: PerSessionAggregate = {
+      sessionId,
+      filePath,
+      project,
+      model,
+      firstTimestamp,
+      lastTimestamp: lastTimestamp || firstTimestamp,
+      inputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheCreateTokens,
+      totalCost,
+    };
+    this._fileCache.set(filePath, { mtimeMs: stat.mtimeMs, size: stat.size, agg });
+    return agg;
+  }
+
+  /**
+   * Walk all sessions on disk and produce a full workspace aggregate. The
+   * `windowFromMs` cap restricts the per-day/per-project/per-model
+   * aggregates to a date range (e.g., this-week); the per-session list is
+   * always full so the UI can sort/filter.
+   */
+  async aggregateAll(
+    windowFromMs: number,
+    windowToMs: number,
+    onProgress?: (done: number, total: number) => void,
+    registryLookup?: (id: string) => { name: string; section: string } | undefined,
+  ): Promise<WorkspaceAggregate> {
+    // Find every .jsonl under ~/.claude/projects/
+    const root = path.join(getClaudeConfigDir(), 'projects');
+    const files = await this._walkJsonl(root);
+
+    const perSession: PerSessionAggregate[] = [];
+    let done = 0;
+    for (const filePath of files) {
+      const agg = await this.aggregateFile(filePath);
+      done += 1;
+      if (onProgress && (done % 25 === 0 || done === files.length)) {
+        onProgress(done, files.length);
+      }
+      if (!agg) continue;
+      if (registryLookup) {
+        const hit = registryLookup(agg.sessionId);
+        if (hit) {
+          agg.registryName = hit.name;
+          agg.registrySection = hit.section;
+        }
+      }
+      perSession.push(agg);
+    }
+
+    // Per-day / per-project / per-model rollups (window-scoped)
+    const dayMap = new Map<string, PerDayAggregate>();
+    const projMap = new Map<string, PerProjectAggregate>();
+    const modelMap = new Map<string, PerModelAggregate>();
+    let totalCost = 0;
+    let totalIn = 0;
+    let totalOut = 0;
+    let totalCR = 0;
+    let totalCC = 0;
+
+    for (const s of perSession) {
+      // A session is "in window" if any of its activity overlaps the window.
+      // For day-bucket aggregation we need per-line resolution we don't
+      // currently keep, so we approximate by attributing the full session
+      // to the day of lastTimestamp when it falls in the window. This is
+      // accurate enough for week-scale views; a future refinement could
+      // attribute per-message.
+      if (s.lastTimestamp < windowFromMs || s.firstTimestamp > windowToMs) continue;
+      totalCost += s.totalCost;
+      totalIn += s.inputTokens;
+      totalOut += s.outputTokens;
+      totalCR += s.cacheReadTokens;
+      totalCC += s.cacheCreateTokens;
+
+      const iso = isoLocalDate(s.lastTimestamp);
+      const day = dayMap.get(iso) || {
+        isoDate: iso, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+        cacheCreateTokens: 0, totalCost: 0, sessionCount: 0,
+      };
+      day.inputTokens += s.inputTokens;
+      day.outputTokens += s.outputTokens;
+      day.cacheReadTokens += s.cacheReadTokens;
+      day.cacheCreateTokens += s.cacheCreateTokens;
+      day.totalCost += s.totalCost;
+      day.sessionCount += 1;
+      dayMap.set(iso, day);
+
+      const proj = projMap.get(s.project) || {
+        project: s.project, sessionCount: 0, inputTokens: 0, outputTokens: 0,
+        cacheReadTokens: 0, cacheCreateTokens: 0, totalCost: 0, lastActivity: 0,
+        modelBreakdown: {},
+      };
+      proj.sessionCount += 1;
+      proj.inputTokens += s.inputTokens;
+      proj.outputTokens += s.outputTokens;
+      proj.cacheReadTokens += s.cacheReadTokens;
+      proj.cacheCreateTokens += s.cacheCreateTokens;
+      proj.totalCost += s.totalCost;
+      proj.lastActivity = Math.max(proj.lastActivity, s.lastTimestamp);
+      proj.modelBreakdown[s.model] = (proj.modelBreakdown[s.model] || 0) + s.totalCost;
+      projMap.set(s.project, proj);
+
+      const m = modelMap.get(s.model) || {
+        model: s.model, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+        cacheCreateTokens: 0, totalCost: 0,
+      };
+      m.inputTokens += s.inputTokens;
+      m.outputTokens += s.outputTokens;
+      m.cacheReadTokens += s.cacheReadTokens;
+      m.cacheCreateTokens += s.cacheCreateTokens;
+      m.totalCost += s.totalCost;
+      modelMap.set(s.model, m);
+    }
+
+    // Fill the per-day array with empty days in the window so the bar chart
+    // renders a continuous spine.
+    const dayCount = Math.max(1, Math.ceil((windowToMs - windowFromMs) / 86400000));
+    const perDay: PerDayAggregate[] = [];
+    for (let i = 0; i < dayCount; i++) {
+      const iso = isoLocalDate(windowFromMs + i * 86400000);
+      perDay.push(dayMap.get(iso) || {
+        isoDate: iso, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+        cacheCreateTokens: 0, totalCost: 0, sessionCount: 0,
+      });
+    }
+    perDay.sort((a, b) => a.isoDate.localeCompare(b.isoDate));
+
+    const perProject = Array.from(projMap.values()).sort((a, b) => b.totalCost - a.totalCost);
+    const perModel = Array.from(modelMap.values()).sort((a, b) => b.totalCost - a.totalCost);
+    perSession.sort((a, b) => b.lastTimestamp - a.lastTimestamp);
+
+    return {
+      windowFrom: windowFromMs,
+      windowTo: windowToMs,
+      totalCost,
+      totalInputTokens: totalIn,
+      totalOutputTokens: totalOut,
+      totalCacheReadTokens: totalCR,
+      totalCacheCreateTokens: totalCC,
+      perDay,
+      perProject,
+      perModel,
+      perSession,
+      scannedFileCount: files.length,
+      scannedAt: Date.now(),
+    };
+  }
+
+  private async _walkJsonl(root: string): Promise<string[]> {
+    const out: string[] = [];
+    async function walk(dir: string, depth: number) {
+      if (depth > 4) return;
+      let entries: fs.Dirent[];
+      try {
+        entries = await fs.promises.readdir(dir, { withFileTypes: true });
+      } catch { return; }
+      for (const e of entries) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) {
+          await walk(full, depth + 1);
+        } else if (e.isFile() && e.name.endsWith('.jsonl')) {
+          out.push(full);
+        }
+      }
+    }
+    await walk(root, 0);
+    return out;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         main: resolve(__dirname, 'webview/index.html'),
+        workspace: resolve(__dirname, 'webview/workspace.html'),
       },
       output: {
         entryFileNames: 'assets/[name].js',

--- a/webview/src/WorkspaceApp.tsx
+++ b/webview/src/WorkspaceApp.tsx
@@ -1,0 +1,371 @@
+import { useEffect, useState, useMemo } from 'react';
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+  PieChart, Pie, Cell, Legend,
+} from 'recharts';
+import './styles/global.css';
+
+// Shape matches src/services/aggregationService.ts WorkspaceAggregate
+interface PerDayAggregate {
+  isoDate: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  totalCost: number;
+  sessionCount: number;
+}
+interface PerProjectAggregate {
+  project: string;
+  sessionCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  totalCost: number;
+  lastActivity: number;
+  modelBreakdown: Record<string, number>;
+}
+interface PerModelAggregate {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  totalCost: number;
+}
+interface PerSessionAggregate {
+  sessionId: string;
+  project: string;
+  model: string;
+  lastTimestamp: number;
+  totalCost: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  registryName?: string;
+  registrySection?: string;
+}
+interface WorkspaceAggregate {
+  windowFrom: number;
+  windowTo: number;
+  totalCost: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheReadTokens: number;
+  totalCacheCreateTokens: number;
+  perDay: PerDayAggregate[];
+  perProject: PerProjectAggregate[];
+  perModel: PerModelAggregate[];
+  perSession: PerSessionAggregate[];
+  scannedFileCount: number;
+  scannedAt: number;
+}
+
+type Tab = 'week' | 'projects';
+type WindowKey = '7d' | '30d' | 'mtd' | 'all';
+
+const MODEL_COLORS: Record<string, string> = {
+  opus: '#c084fc',
+  sonnet: '#60a5fa',
+  haiku: '#34d399',
+  unknown: '#94a3b8',
+};
+
+function normalizeModel(m: string): string {
+  if (!m) return 'unknown';
+  if (m.includes('opus')) return 'opus';
+  if (m.includes('sonnet')) return 'sonnet';
+  if (m.includes('haiku')) return 'haiku';
+  return 'unknown';
+}
+
+function fmtUSD(n: number): string {
+  if (n >= 100) return `$${n.toFixed(0)}`;
+  if (n >= 10) return `$${n.toFixed(2)}`;
+  return `$${n.toFixed(3)}`;
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function fmtDate(iso: string): string {
+  // "2026-05-26" -> "May 26"
+  const d = new Date(iso + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function fmtRelative(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return 'just now';
+  if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.round(diff / 3_600_000)}h ago`;
+  return `${Math.round(diff / 86_400_000)}d ago`;
+}
+
+function fmtProject(project: string): string {
+  // discoveryService stores project as the directory slug "C--Users-mered-..."
+  // -> trim to last path token for readability.
+  const parts = project.replace(/^C--/, '').split('-');
+  return parts.slice(-3).join('-') || project;
+}
+
+export default function WorkspaceApp() {
+  const [data, setData] = useState<WorkspaceAggregate | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+  const [tab, setTab] = useState<Tab>('week');
+  const [windowKey, setWindowKey] = useState<WindowKey>('7d');
+  const [projectSort, setProjectSort] = useState<'cost' | 'sessions' | 'recent'>('cost');
+
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      const msg = e.data;
+      if (msg.type === 'workspaceData') {
+        setData(msg.data);
+        setLoading(false);
+        setProgress(null);
+      } else if (msg.type === 'workspaceProgress') {
+        setProgress({ done: msg.done, total: msg.total });
+      } else if (msg.type === 'workspaceLoading') {
+        setLoading(true);
+      }
+    };
+    window.addEventListener('message', handler);
+    window.vscodeApi?.postMessage({ type: 'ready', window: windowKey });
+    return () => window.removeEventListener('message', handler);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const requestWindow = (w: WindowKey) => {
+    setWindowKey(w);
+    setLoading(true);
+    setData(null);
+    window.vscodeApi?.postMessage({ type: 'setWindow', window: w });
+  };
+
+  const refresh = () => {
+    setLoading(true);
+    setData(null);
+    window.vscodeApi?.postMessage({ type: 'refresh' });
+  };
+
+  const sortedProjects = useMemo(() => {
+    if (!data) return [];
+    const arr = [...data.perProject];
+    if (projectSort === 'sessions') arr.sort((a, b) => b.sessionCount - a.sessionCount);
+    else if (projectSort === 'recent') arr.sort((a, b) => b.lastActivity - a.lastActivity);
+    else arr.sort((a, b) => b.totalCost - a.totalCost);
+    return arr;
+  }, [data, projectSort]);
+
+  const modelPieData = useMemo(() => {
+    if (!data) return [];
+    return data.perModel.map((m) => ({
+      name: normalizeModel(m.model),
+      fullModel: m.model,
+      value: m.totalCost,
+    }));
+  }, [data]);
+
+  return (
+    <div className="ws-root">
+      <header className="ws-header">
+        <div className="ws-title">
+          <span className="ws-title-main">Workspace</span>
+          <span className="ws-title-sep">·</span>
+          <span className="ws-title-sub">Cross-session token + cost rollup</span>
+        </div>
+        <div className="ws-window">
+          {(['7d', '30d', 'mtd', 'all'] as WindowKey[]).map((w) => (
+            <button
+              key={w}
+              className={`ws-window-btn${windowKey === w ? ' active' : ''}`}
+              onClick={() => requestWindow(w)}
+              type="button"
+            >
+              {w === '7d' ? 'Last 7 days' : w === '30d' ? 'Last 30 days' : w === 'mtd' ? 'Month to date' : 'All time'}
+            </button>
+          ))}
+          <button className="ws-refresh" onClick={refresh} type="button" title="Re-scan all JSONLs">
+            ↻
+          </button>
+        </div>
+      </header>
+
+      <nav className="ws-tabs">
+        <button className={`ws-tab${tab === 'week' ? ' active' : ''}`} onClick={() => setTab('week')} type="button">
+          Window summary
+        </button>
+        <button className={`ws-tab${tab === 'projects' ? ' active' : ''}`} onClick={() => setTab('projects')} type="button">
+          By project
+        </button>
+      </nav>
+
+      {loading && (
+        <div className="ws-loading">
+          <div className="ws-spinner" />
+          <div>
+            Scanning JSONLs{progress ? ` (${progress.done} / ${progress.total})` : ''}…
+          </div>
+        </div>
+      )}
+
+      {!loading && data && tab === 'week' && (
+        <section className="ws-section">
+          <div className="ws-stat-grid">
+            <Stat label="Total cost" value={fmtUSD(data.totalCost)} />
+            <Stat label="Input tokens" value={fmtTokens(data.totalInputTokens)} />
+            <Stat label="Output tokens" value={fmtTokens(data.totalOutputTokens)} />
+            <Stat label="Cache read" value={fmtTokens(data.totalCacheReadTokens)} />
+            <Stat label="Cache write" value={fmtTokens(data.totalCacheCreateTokens)} />
+            <Stat label="Sessions scanned" value={String(data.scannedFileCount)} />
+          </div>
+
+          <div className="ws-row">
+            <div className="ws-card ws-card-chart">
+              <h3>Daily cost</h3>
+              <ResponsiveContainer width="100%" height={220}>
+                <BarChart data={data.perDay} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(128,128,128,0.18)" />
+                  <XAxis
+                    dataKey="isoDate"
+                    tickFormatter={fmtDate}
+                    tick={{ fontSize: 11 }}
+                    stroke="rgba(128,128,128,0.6)"
+                  />
+                  <YAxis tickFormatter={(v) => fmtUSD(v)} tick={{ fontSize: 11 }} stroke="rgba(128,128,128,0.6)" />
+                  <Tooltip
+                    formatter={(v: number) => fmtUSD(v)}
+                    labelFormatter={fmtDate}
+                    contentStyle={{
+                      background: 'var(--vscode-editor-background)',
+                      border: '1px solid var(--vscode-widget-border)',
+                      fontSize: 12,
+                    }}
+                  />
+                  <Bar dataKey="totalCost" fill="var(--vscode-charts-blue, #60a5fa)" radius={[3, 3, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+
+            <div className="ws-card ws-card-chart">
+              <h3>Spend by model</h3>
+              <ResponsiveContainer width="100%" height={220}>
+                <PieChart>
+                  <Pie
+                    data={modelPieData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={50}
+                    outerRadius={80}
+                    paddingAngle={2}
+                  >
+                    {modelPieData.map((entry, i) => (
+                      <Cell key={i} fill={MODEL_COLORS[entry.name] || '#94a3b8'} />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    formatter={(v: number, _name: any, props: any) => [fmtUSD(v), props?.payload?.fullModel]}
+                    contentStyle={{
+                      background: 'var(--vscode-editor-background)',
+                      border: '1px solid var(--vscode-widget-border)',
+                      fontSize: 12,
+                    }}
+                  />
+                  <Legend formatter={(v) => v.charAt(0).toUpperCase() + v.slice(1)} />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          <div className="ws-card">
+            <h3>Top projects this window</h3>
+            <table className="ws-table">
+              <thead>
+                <tr>
+                  <th>Project</th>
+                  <th className="num">Sessions</th>
+                  <th className="num">Input</th>
+                  <th className="num">Output</th>
+                  <th className="num">Cache read</th>
+                  <th className="num">Cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.perProject.slice(0, 5).map((p) => (
+                  <tr key={p.project}>
+                    <td title={p.project}>{fmtProject(p.project)}</td>
+                    <td className="num">{p.sessionCount}</td>
+                    <td className="num">{fmtTokens(p.inputTokens)}</td>
+                    <td className="num">{fmtTokens(p.outputTokens)}</td>
+                    <td className="num">{fmtTokens(p.cacheReadTokens)}</td>
+                    <td className="num">{fmtUSD(p.totalCost)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {!loading && data && tab === 'projects' && (
+        <section className="ws-section">
+          <div className="ws-projectsort">
+            Sort by:&nbsp;
+            <button className={`ws-sortbtn${projectSort === 'cost' ? ' active' : ''}`} onClick={() => setProjectSort('cost')} type="button">Cost</button>
+            <button className={`ws-sortbtn${projectSort === 'sessions' ? ' active' : ''}`} onClick={() => setProjectSort('sessions')} type="button">Sessions</button>
+            <button className={`ws-sortbtn${projectSort === 'recent' ? ' active' : ''}`} onClick={() => setProjectSort('recent')} type="button">Most recent</button>
+          </div>
+          <div className="ws-card">
+            <table className="ws-table">
+              <thead>
+                <tr>
+                  <th>Project</th>
+                  <th className="num">Sessions</th>
+                  <th className="num">Input</th>
+                  <th className="num">Output</th>
+                  <th className="num">Cache R</th>
+                  <th className="num">Cache W</th>
+                  <th className="num">Cost</th>
+                  <th>Last activity</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedProjects.map((p) => (
+                  <tr key={p.project}>
+                    <td title={p.project}>{fmtProject(p.project)}</td>
+                    <td className="num">{p.sessionCount}</td>
+                    <td className="num">{fmtTokens(p.inputTokens)}</td>
+                    <td className="num">{fmtTokens(p.outputTokens)}</td>
+                    <td className="num">{fmtTokens(p.cacheReadTokens)}</td>
+                    <td className="num">{fmtTokens(p.cacheCreateTokens)}</td>
+                    <td className="num">{fmtUSD(p.totalCost)}</td>
+                    <td>{fmtRelative(p.lastActivity)}</td>
+                  </tr>
+                ))}
+                {sortedProjects.length === 0 && (
+                  <tr><td colSpan={8} style={{ textAlign: 'center', padding: '20px', opacity: 0.6 }}>No projects in this window.</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="ws-stat">
+      <div className="ws-stat-label">{label}</div>
+      <div className="ws-stat-value">{value}</div>
+    </div>
+  );
+}

--- a/webview/src/main-workspace.tsx
+++ b/webview/src/main-workspace.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import WorkspaceApp from './WorkspaceApp';
+
+const vscode = acquireVsCodeApi();
+window.vscodeApi = vscode;
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <WorkspaceApp />
+  </React.StrictMode>
+);
+
+declare function acquireVsCodeApi(): {
+  postMessage: (message: any) => void;
+  getState: () => any;
+  setState: (state: any) => void;
+};

--- a/webview/src/styles/global.css
+++ b/webview/src/styles/global.css
@@ -107,3 +107,229 @@ code, pre {
 .fade-in {
   animation: fadeIn 0.2s ease-out;
 }
+/* ─── Workspace Dashboard ───────────────────────────────────────────── */
+
+.ws-root {
+  font-family: 'Inter', system-ui, sans-serif;
+  color: var(--text);
+  padding: 16px 22px;
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+.ws-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 14px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.ws-title {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.ws-title-main {
+  font-size: 18px;
+  font-weight: 700;
+}
+.ws-title-sep {
+  color: var(--text-dim);
+}
+.ws-title-sub {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.ws-window {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.ws-window-btn,
+.ws-refresh {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  padding: 3px 10px;
+  font: inherit;
+  font-size: 12px;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.ws-window-btn:hover,
+.ws-refresh:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+.ws-window-btn.active {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  border-color: var(--vscode-button-background);
+}
+.ws-refresh {
+  font-size: 14px;
+  padding: 3px 8px;
+}
+
+.ws-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+.ws-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  padding: 7px 14px;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s;
+}
+.ws-tab:hover {
+  color: var(--text);
+}
+.ws-tab.active {
+  color: var(--text);
+  border-bottom-color: var(--vscode-button-background);
+}
+
+.ws-loading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 28px 0;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+.ws-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border);
+  border-top-color: var(--vscode-button-background);
+  border-radius: 50%;
+  animation: ws-spin 0.8s linear infinite;
+}
+@keyframes ws-spin { to { transform: rotate(360deg); } }
+
+.ws-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ws-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+}
+.ws-stat {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 10px 12px;
+}
+.ws-stat-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+}
+.ws-stat-value {
+  font-size: 18px;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--text-bright);
+}
+
+.ws-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 16px;
+}
+@media (max-width: 900px) {
+  .ws-row { grid-template-columns: 1fr; }
+}
+
+.ws-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 12px 14px;
+}
+.ws-card h3 {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  margin-bottom: 10px;
+}
+
+.ws-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+}
+.ws-table th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+  padding: 6px 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.ws-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+  font-family: 'JetBrains Mono', monospace;
+}
+.ws-table td:first-child,
+.ws-table th:first-child {
+  font-family: 'Inter', sans-serif;
+}
+.ws-table .num {
+  text-align: right;
+}
+.ws-table tr:last-child td {
+  border-bottom: none;
+}
+.ws-table tr:hover td {
+  background: var(--bg-hover);
+}
+
+.ws-projectsort {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.ws-sortbtn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  padding: 2px 8px;
+  font: inherit;
+  font-size: 11.5px;
+  border-radius: 3px;
+  cursor: pointer;
+  margin-left: 4px;
+}
+.ws-sortbtn:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+.ws-sortbtn.active {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  border-color: var(--vscode-button-background);
+}

--- a/webview/workspace.html
+++ b/webview/workspace.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Argus Workspace Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main-workspace.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
Hey! Argus is a fantastic piece of work — installed it earlier today, hooked it up to my Claude Code session history, and the per-session depth is exactly the kind of observability I wanted. Thank you.

After a couple hours of using it I found myself wanting the **cross-session** view too: per-project rollups, weekly token totals, and a place to answer "where did the cost go this week" without opening individual sessions. So I built it as an additive feature and figured I'd send it back rather than keep it in a fork. All happy to iterate on if any of it feels off for the project's direction.

## What this adds

A new singleton webview panel — **Workspace Dashboard** — that aggregates token usage and cost across every JSONL under `~/.claude/projects/`. Opens via a new sidebar title-bar button (or `Argus: Open Workspace Dashboard` from the command palette).

**Window selector at top:** Last 7 days · Last 30 days · Month to date · All time. Re-aggregates on click with a streaming progress indicator.

**Window summary tab:**
- 6 stat cards: total cost, input / output / cache-read / cache-write tokens, sessions scanned
- Daily cost bar chart (recharts — already a dep)
- Spend-by-model donut (Opus / Sonnet / Haiku / unknown), colored
- Top-5 projects for the window

**By project tab:**
- Sortable table (cost / sessions / most recent)
- Per-project totals: sessions, tokens by class, cost, last activity

## Architecture

| File | Role |
|---|---|
| `src/services/aggregationService.ts` | Streams every JSONL line-by-line via readline (no full-transcript parse), sums `message.usage` from assistant responses, per-file mtime+size cache for fast repeat opens, rolls per-session → per-project/day/model |
| `src/providers/workspaceDashboardProvider.ts` | Singleton webview panel, CSP-locked HTML, message protocol for ready/setWindow/refresh and workspaceData/Progress/Loading |
| `webview/workspace.html` + `main-workspace.tsx` + `WorkspaceApp.tsx` | Second Vite entry, builds to `out/webview/assets/workspace.js`. Recharts for the daily bar + model donut. Theme-aware via existing VS Code CSS variables. |

**Wiring changes:**
- `vite.config.ts` — adds a `workspace` rollup input alongside `main`
- `src/extension.ts` — instantiates `AggregationService` and registers the new command
- `package.json` — declares the command + adds a dashboard icon to the Sessions view title bar (navigation@0, so it sits before clearFilters + refresh)
- `webview/src/styles/global.css` — appends `.ws-*` component styles

## Performance

First open scans every JSONL once; subsequent opens hit the mtime+size cache and only re-aggregate files that changed. Progress callback fires every 25 files so the UI shows `Scanning JSONLs (N / M)…` during the initial scan.

## Backward compatibility

Pure addition. No changes to existing session-detail behavior, the session list, or any current commands. Vanilla session viewing continues to work exactly as before.

## What I'd love your eye on

1. **Project name display** — I currently strip the `C--` prefix and take the last three hyphen-segments for readability. Open to a different convention if you prefer the raw directory slug or something else.
2. **Daily attribution heuristic** — I attribute each session's full cost to the day of its `lastTimestamp`. Accurate at week scale; a per-message attribution refinement could come later. Happy to wire that in if you'd like it now.
3. **Optional registryLookup parameter on aggregateAll** — I left this in the signature with a no-op default because I have a downstream fork that uses it to tag sessions with friendly names from a user-maintained registry. Trivial to remove if you'd rather not carry the optional param; it's invisible to vanilla callers.
4. **Bundle size** — the workspace bundle is ~49 kB minified (mostly recharts). Acceptable I think, but if you'd like `react-chartjs-2` swapped in instead (which is also already a dep) I'm happy to do that pass.

Tested on Windows with ~200 sessions across 15 project directories — full scan completes in ~600 ms cold, ~50 ms warm. No regressions observed in the existing session viewer.

Let me know what you think! Happy to split this into smaller commits, change naming, rework the UI, or anything else that helps it land.

— Meredith